### PR TITLE
Avoid Math.random() for Random#integer

### DIFF
--- a/lib/Random.ts
+++ b/lib/Random.ts
@@ -65,7 +65,7 @@ export class Random {
 
   /** Returns a random integer between min and max, inclusive */
   public integer(min: number, max: number): number {
-    return Math.floor(Math.random() * (max - min + 1)) + min;
+    return Math.floor(this.next() * (max - min + 1)) + min;
   }
 
   /** Returns true if a random number falls within a given probability */

--- a/tests/Random-test.ts
+++ b/tests/Random-test.ts
@@ -25,3 +25,11 @@ tape("Random.getDiceNotationRange", (t) => {
   t.equal(range.max, 11);
   t.end();
 });
+
+tape("Random#integer", (t) => {
+  const rng = new Random(5);
+  t.equal(rng.integer(1, 6), 4);
+  t.equal(rng.integer(1, 6), 2);
+  t.equal(rng.integer(1, 6), 6);
+  t.end();
+});


### PR DESCRIPTION
Hello!

I was browsing through and found what I _think_ is a bug: `Random.prototype.integer` used `Math.random()` instead of the seeded value.

No worries if this is too much trouble to merge, or if I misinterpreted the intent behind this library. The show notes from Lostcast led me here!

